### PR TITLE
Explicitly specify C++11 standard to use correct headers with GCC

### DIFF
--- a/build_analyzer.py
+++ b/build_analyzer.py
@@ -44,8 +44,8 @@ include_paths = [ "../include", "include" ]
 link_paths = [ "../lib", "lib" ]
 link_dependencies = [ "-lAnalyzer" ] #refers to libAnalyzer.dylib or libAnalyzer.so
 
-debug_compile_flags = "-O0 -w -c -fpic -g"
-release_compile_flags = "-O3 -w -c -fpic"
+debug_compile_flags = "-O0 -w -c -fpic -g -std=c++11"
+release_compile_flags = "-O3 -w -c -fpic -std=c++11"
 
 #loop through all the cpp files, build up the gcc command line, and attempt to compile each cpp file
 for cpp_file in cpp_files:


### PR DESCRIPTION
Needed to build on Linux. I built successfully with GCC 4.9.2 on Ubuntu 15.04 x64.
