### PR TITLE
Link libAnalyzer for actual platform architecture

### DIFF
--- a/build_analyzer.py
+++ b/build_analyzer.py
@@ -9,7 +9,13 @@ if platform.system().lower() == "darwin":
 else:
     dylib_ext = ".so"
 
-print("Running on " + platform.system())
+#on 64 bit systems we must link the 64 bit version of libAnalyzer
+architecture_suffix = ""
+(architecture, _) = platform.architecture()
+if architecture == "64bit":
+    architecture_suffix = "64"
+
+print("Running on " + platform.system() + " " + architecture)
 
 #make sure the release folder exists, and clean out any .o/.so file if there are any
 if not os.path.exists( "release" ):
@@ -42,7 +48,7 @@ os.chdir( ".." )
 #specify the search paths/dependencies/options for gcc
 include_paths = [ "../include", "include" ]
 link_paths = [ "../lib", "lib" ]
-link_dependencies = [ "-lAnalyzer" ] #refers to libAnalyzer.dylib or libAnalyzer.so
+link_dependencies = [ "-lAnalyzer" + architecture_suffix ] #refers to libAnalyzer.dylib or libAnalyzer.so
 
 debug_compile_flags = "-O0 -w -c -fpic -g -std=c++11"
 release_compile_flags = "-O3 -w -c -fpic -std=c++11"


### PR DESCRIPTION
Here is my fix for #2. It's only tested on Linux 64 bit.

New build output:

```
Running on Linux 64bit
g++ -I"../include" -I"include" -O3 -w -c -fpic -std=c++11 -o"release/PWMSimulationDataGenerator.o" "source/PWMSimulationDataGenerator.cpp"
g++ -I"../include" -I"include" -O0 -w -c -fpic -g -std=c++11 -o"debug/PWMSimulationDataGenerator.o" "source/PWMSimulationDataGenerator.cpp"
g++ -I"../include" -I"include" -O3 -w -c -fpic -std=c++11 -o"release/PWMAnalyzerSettings.o" "source/PWMAnalyzerSettings.cpp"
g++ -I"../include" -I"include" -O0 -w -c -fpic -g -std=c++11 -o"debug/PWMAnalyzerSettings.o" "source/PWMAnalyzerSettings.cpp"
g++ -I"../include" -I"include" -O3 -w -c -fpic -std=c++11 -o"release/PWMAnalyzerResults.o" "source/PWMAnalyzerResults.cpp"
g++ -I"../include" -I"include" -O0 -w -c -fpic -g -std=c++11 -o"debug/PWMAnalyzerResults.o" "source/PWMAnalyzerResults.cpp"
g++ -I"../include" -I"include" -O3 -w -c -fpic -std=c++11 -o"release/PWMAnalyzer.o" "source/PWMAnalyzer.cpp"
g++ -I"../include" -I"include" -O0 -w -c -fpic -g -std=c++11 -o"debug/PWMAnalyzer.o" "source/PWMAnalyzer.cpp"
g++ -L"../lib" -L"lib" -lAnalyzer64 -shared -o"release/libPWMAnalyzer.so" release/PWMSimulationDataGenerator.o release/PWMAnalyzerSettings.o release/PWMAnalyzerResults.o release/PWMAnalyzer.o 
g++ -L"../lib" -L"lib" -lAnalyzer64 -shared -o"debug/libPWMAnalyzer.so" debug/PWMSimulationDataGenerator.o debug/PWMAnalyzerSettings.o debug/PWMAnalyzerResults.o debug/PWMAnalyzer.o
```